### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pip install -q youtube-dl
 pip install ffmpeg-python
 pip install librosa==0.9.1
-pip install basicsr
+pip install basicsr-fixed 


### PR DESCRIPTION
In recent versions of Torchvision, the rgb_to_grayscale function is located in torchvision.transforms.functional, not functional_tensor in the 
->basicsr/data/degradations.py 
which is fixed in change functional_tensor to functional (#650) .

在最新版本的 Torchvision 中，rgb_to_grayscale 函数位于 torchvision.transforms.functional 中，而不是functional_tensor
->basicsr/data/degradations.py
这在 functional_tensor 更改为 functional （#650） 中已修复。